### PR TITLE
Allow equipping two Jewels of Froz with soldier shield

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -10754,7 +10754,8 @@ messages:
    RefreshPlayerVisualGear()
    {
       local n, lRefreshItemTypes, i, iHighestLayer, oHighestGear,
-            iLowestLayer, oLowestGear, oSoldierShield, bSoldierShieldSlung;
+            iLowestLayer, oLowestGear, oSoldierShield, bSoldierShieldSlung,
+            iFrozCount;
 
       lRefreshItemTypes = [ITEM_USE_SHIRT,ITEM_USE_BODY,ITEM_USE_LEGS];
 
@@ -10809,12 +10810,19 @@ messages:
       oSoldierShield = Send(self,@FindUsing,#class=&SoldierShield);
       if oSoldierShield <> $
       {
+         iFrozCount = 0;
          foreach i in plUsing
          {
+            if IsClass(i,&JewelOfFroz)
+            {
+               iFrozCount++;
+            }
+
             if (IsClass(i,&Shield)
                AND NOT IsClass(i,&SoldierShield))
                OR IsClass(i,&Bow)
                OR IsClass(i,&Lute)
+               OR iFrozCount > 1
             {
                Send(oSoldierShield,@SlingOnBack,#report=FALSE);
                bSoldierShieldSlung = TRUE;

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -446,6 +446,8 @@ messages:
          OR IsClass(what,&Bow)
          OR IsClass(what,&Lute)
          OR IsClass(what,&Totem)
+         OR (IsClass(what,&JewelofFroz)
+            AND Send(poOwner,@IsUsingA,#class=&JewelofFroz))
       {
          Send(self,@SlingOnBack,#report=FALSE);
 


### PR DESCRIPTION
This slings the shield on the back on the attempt to equip the second jewel. It also rechecks for two jewels in the RefreshPlayerVisualGear function in player.kod.

This doesn't affect balance so much as it just fixes an oversight.