### PR TITLE
Potions, Wands, Scrolls factor independence

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -233,8 +233,7 @@ messages:
    CastSpell(what=$,apply_on=$)
    "Casts the spell set by the spell object"
    {
-      local oSpell, iSpellPower, iRand, iInt, lTargets, oModifierSpell,
-            iSPLoss, oRoom, iCost, i;
+      local oSpell, iSpellPower, lTargets, iCost, i;
 
       oSpell = Send(SYS,@FindSpellByNum,#num=viSpellEffect);
 
@@ -261,6 +260,7 @@ messages:
                      #bItemCast=TRUE);
       if (iCost > 0
          AND Send(what,@GetMana) < iCost)
+         AND Send(SETTINGS_OBJECT,@GetSpellItemsCostMana)
       {
          Send(what,@MsgSendUser,#message_rsc=spellitem_no_mana,
                #parm1=Send(self,@GetDef),#parm2=Send(self,@GetName));
@@ -278,33 +278,6 @@ messages:
          return;
       }
 
-      oRoom = Send(poOwner,@GetOwner);
-
-      // AMA modifies item spellpower.
-      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_ANTI_MAGIC)
-      {
-         oModifierSpell = Send(SYS,@FindSpellByNum,#num=SID_ANTIMAGIC_AURA);
-         iSpellPower = Send(oModifierSpell,@ModifySpellPower,
-                              #oRoom=oRoom,#oSpell=oSpell);
-      }
-
-      // Mana convergence adds spellpower.
-      foreach i in Send(poOwner,@GetRadiusEnchantments)
-      {
-         iSpellPower = Send(Nth(i,2),@ModifySpellPower,#who=poOwner,
-                           #oSpell=oSpell,#iSpellPower=iSpellPower,
-                           #state=Nth(i,3));
-      }
-
-      // Owner of spellitem being demented reduces item spellpower.
-      oModifierSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENT);
-      if Send(poOwner,@IsEnchanted,#what=oModifierSpell)
-      {
-         iSPLoss = First(Send(poOwner,@GetEnchantedState,#what=oModifierSpell));
-         iSPLoss = Random(iSPLoss, iSPLoss * 2);
-         iSpellPower = iSpellPower - iSPLoss;
-      }
-
       iSpellPower = Bound(iSpellPower, SPELLPOWER_MINIMUM, SPELLPOWER_MAXIMUM);
 
       if (vbFailSafe)
@@ -315,7 +288,10 @@ messages:
                    OR Send(Send(what,@GetOwner),@ReqSomethingAttack,#what=what,
                             #victim=apply_on)) )
       {
-         Send(what,@LoseMana,#amount=iCost);
+         if Send(SETTINGS_OBJECT,@GetSpellItemsCostMana)
+         {
+            Send(what,@LoseMana,#amount=iCost);
+         }
          Send(oSpell,@CastSpell,#who=poOwner,#lTargets=lTargets,
                #iSpellPower=iSpellPower,#bItemCast=TRUE);
       }

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -315,6 +315,11 @@ properties:
    // the flag needs to be manually removed from players.
    pbPvPOptOutEnabled = TRUE
 
+   // Do spell items cost mana to use?
+   // Mana costs were added mainly in response to ogre being
+   // much more powerful with these items.
+   pbSpellItemsCostMana = FALSE
+
 messages:
 
    Constructor()
@@ -780,6 +785,11 @@ messages:
    PvPOptOutEnabled()
    {
       return pbPvPOptOutEnabled;
+   }
+
+   GetSpellItemsCostMana()
+   {
+      return pbSpellItemsCostMana;
    }
 
 end


### PR DESCRIPTION
Spell items are no longer affected by AMA, dement, or mana convergence.

A new setting in settings.kod controls whether spell items cost mana. It's defaulted to false. Originally, spell items were made to cost mana because Ogre was so powerful with them. That's not really the case at the moment. However, this setting preserves the ability for an admin to live-change it back to costing mana.