### PR TITLE
Denial banned in arena

### DIFF
--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -146,5 +146,10 @@ messages:
       return &DenialPotion;
    }
 
+   SpellBannedInArena()
+   {
+      return TRUE;
+   }
+
 end
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Denial no longer works in the arena due to its abusability. (And how ridiculous it gets when both combatants are just denial potting back and forth)