### PR TITLE
Scale Jonas damage bonus with power

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5523,10 +5523,10 @@ messages:
                               #state=Nth(i,3),#damage=iDamageBonus);
       }
 
-      iDamageBonus += Send(Send(SYS,@GetParliament),@GetFactionDamageBonus,#who=self);
-
       // Convert to high precision. Super dirty, will be cleaned up shortly.
       iDamageBonus *= 100;
+
+      iDamageBonus += Send(Send(SYS,@GetParliament),@GetFactionDamageBonus,#who=self);
 
       iDamage += iDamageBonus;
 

--- a/kod/util/parlia.kod
+++ b/kod/util/parlia.kod
@@ -1319,7 +1319,7 @@ messages:
               #parm1=Send(self,@GetFactionLiege,#faction=iFaction));
       }
       
-      return 2;
+      return Bound(100 + Send(self,@CalcFactionBonus,#base=140,#faction=iFaction),100,300);
    }
 
    GetFactionRegenBonus(who=$, hpregen=TRUE)


### PR DESCRIPTION
Jonas' damage bonus, instead of being a flat +2, will now be a high-precision 1 damage flat plus up to 2 damage based on power, for a total of +3 damage at full power.