### PR TITLE
Magic Spirit Helm blind resistance property

### DIFF
--- a/kod/object/item/passitem/defmod/helmet/helm.kod
+++ b/kod/object/item/passitem/defmod/helmet/helm.kod
@@ -42,7 +42,6 @@ classvars:
 
    viUse_type = ITEM_USE_HEAD
    viUse_amount = 1
-   viSpell_modifier = -5
 
    viGround_group = 2
    viInventory_group = 2
@@ -55,6 +54,9 @@ classvars:
    viDamage_base = 1
 
 properties:
+
+   viSpell_modifier = 5
+   piBlindReductionPercentage = 15
 
 messages:
 
@@ -103,6 +105,11 @@ messages:
    {
       // Special item, add minimap dot.
       return MM_RARE_ITEM;
+   }
+
+   GetBlindReductionPercentage()
+   {
+      return piBlindReductionPercentage;
    }
 
 end

--- a/kod/object/passive/spell/debuff/blind.kod
+++ b/kod/object/passive/spell/debuff/blind.kod
@@ -103,7 +103,7 @@ messages:
 
    DoSpell(what=$,oTarget=$,iDuration=0)
    {
-      local oSpell;
+      local oSpell, oHelm;
 
       oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
       if Send(oTarget,@IsEnchanted,#what=oSpell)
@@ -122,6 +122,12 @@ messages:
 
       if IsClass(oTarget,&User)
       {
+         oHelm = Send(oTarget,@FindUsing,#class=&Helm);
+         if oHelm <> $
+         {
+            iDuration = Bound((iDuration * (100-Send(oHelm,@GetBlindReductionPercentage)))/100,1,$);
+         }
+
          if NOT (IsClass(oTarget,&DM) AND Send(oTarget,@PlayerIsImmortal))
          {
             Send(oTarget,@MsgSendUser,#message_rsc=vrEnchantment_On);

--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -92,7 +92,7 @@ messages:
 
    DoSpell(what=$,oTarget=$,iDuration=0)
    {
-      local oSpell;
+      local oSpell, oHelm;
 
       oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
       if Send(oTarget,@IsEnchanted,#what=oSpell)
@@ -111,6 +111,12 @@ messages:
 
       if IsClass(oTarget,&User)
       {
+         oHelm = Send(oTarget,@FindUsing,#class=&Helm);
+         if oHelm <> $
+         {
+            iDuration = Bound((iDuration * (100-Send(oHelm,@GetBlindReductionPercentage)))/100,1,$);
+         }
+
          Send(oTarget,@MsgSendUser,#message_rsc=vrEnchantment_On);
          Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,
                #duration=iDuration);


### PR DESCRIPTION
Blind and Dazzle reduced by default 15% duration by wearing a magic spirit helm.  Can be changed by admin for prize purposes.

Spell modifier also changed to property and defaulted to +5 by request. Admins can make more effective MSHs in this property as well if desired.